### PR TITLE
Ignore "realm" parameter in Authorization header

### DIFF
--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -15,6 +15,8 @@ function parseParameters( method, headers, query, body ) {
   if(headers['authorization'] != null && headers['authorization'].indexOf('OAuth') != -1) {
     result= authutils.splitAuthorizationHeader(headers['authorization']);
     delete result.type;
+    // Exclude the "realm" parameter per Section 3.4.1.3.1 of RFC 5849
+    delete result.realm;
   }
 
   //TODO: Figure out how to use post params....


### PR DESCRIPTION
The OAuth spec states that the "realm" parameter should not be included in the signature (see Section 3.4.1.3.1 of RFC 5849: http://tools.ietf.org/html/rfc5849#section-3.4.1.3.1 ). This patch removes this parameter before validating the signature.

Thanks for your work on connect-auth!
