### PR TITLE
Add option to handle authentication errors by the application

### DIFF
--- a/lib/auth.strategies/http/base.js
+++ b/lib/auth.strategies/http/base.js
@@ -2,19 +2,35 @@
  * Copyright(c) 2010 Ciaran Jessup <ciaranj@gmail.com>
  * MIT Licensed
  */
-Base= module.exports= function () {
-  var that= {};
-  that._badRequest= function(executionScope, req, res, callback, attributes) {
-    res.writeHead(400, { 'Content-Type': 'text/plain',
-                         'WWW-Authenticate': this.getAuthenticateResponseHeader(executionScope, attributes) });
-    res.end('Bad Request');
-    executionScope.halt(callback);
+Base= module.exports= function (options) {
+  var that = {};
+  var my = {};
+  my._isAutoRespond = options.isAutoRespond || true;
+
+  that._badRequest = function (executionScope, req, res, callback, attributes) {
+    var authHeader = this.getAuthenticateResponseHeader(executionScope, attributes);
+    if (my._isAutoRespond) {
+      res.writeHead(400, { 'Content-Type': 'text/plain',
+                           'WWW-Authenticate': authHeader });
+      res.end('Bad Request');
+      executionScope.halt(callback);
+    }
+    else {
+      executionScope.halt(callback, { code: 400, header: authHeader, attributes: attributes });
+    }
   };
   that._unAuthenticated= function(executionScope, req, res, callback, attributes) {  
-    res.writeHead(401, { 'Content-Type': 'text/plain',
-                         'WWW-Authenticate': this.getAuthenticateResponseHeader(executionScope, attributes) });
-    res.end("Authorization Required");
-    executionScope.halt(callback);
+    var authHeader = this.getAuthenticateResponseHeader(executionScope, attributes);
+    if (my._isAutoRespond) {
+        res.writeHead(401, { 'Content-Type': 'text/plain',
+                             'WWW-Authenticate': authHeader
+        });
+        res.end('Authorization Required');
+        executionScope.halt(callback);
+    }
+    else {
+        executionScope.halt(callback, { code: 401, header: authHeader, attributes: attributes });
+    }
   };
   return that;
 };

--- a/lib/auth.strategies/http/base.js
+++ b/lib/auth.strategies/http/base.js
@@ -5,7 +5,7 @@
 Base= module.exports= function (options) {
   var that = {};
   var my = {};
-  my._isAutoRespond = options.isAutoRespond || true;
+  my._isAutoRespond = (options.isAutoRespond == null ? true : options.isAutoRespond);
 
   that._badRequest = function (executionScope, req, res, callback, attributes) {
     var authHeader = this.getAuthenticateResponseHeader(executionScope, attributes);
@@ -14,7 +14,7 @@ Base= module.exports= function (options) {
                            'WWW-Authenticate': authHeader });
       res.end('Bad Request');
     }
-    executionScope.errorResponse({ code: 400, header: authHeader, attributes: attributes });
+    executionScope.executionResult.errorResponse = { code: 400, header: authHeader, attributes: attributes };
     executionScope.halt(callback);
   };
   that._unAuthenticated= function(executionScope, req, res, callback, attributes) {  
@@ -25,7 +25,7 @@ Base= module.exports= function (options) {
         });
         res.end('Authorization Required');
     }
-    executionScope.errorResponse({ code: 401, header: authHeader, attributes: attributes });
+    executionScope.executionResult.errorResponse = { code: 401, header: authHeader, attributes: attributes };
     executionScope.halt(callback);
   };
   return that;

--- a/lib/auth.strategies/http/base.js
+++ b/lib/auth.strategies/http/base.js
@@ -13,11 +13,9 @@ Base= module.exports= function (options) {
       res.writeHead(400, { 'Content-Type': 'text/plain',
                            'WWW-Authenticate': authHeader });
       res.end('Bad Request');
-      executionScope.halt(callback);
     }
-    else {
-      executionScope.halt(callback, { code: 400, header: authHeader, attributes: attributes });
-    }
+    executionScope.errorResponse({ code: 400, header: authHeader, attributes: attributes });
+    executionScope.halt(callback);
   };
   that._unAuthenticated= function(executionScope, req, res, callback, attributes) {  
     var authHeader = this.getAuthenticateResponseHeader(executionScope, attributes);
@@ -26,11 +24,9 @@ Base= module.exports= function (options) {
                              'WWW-Authenticate': authHeader
         });
         res.end('Authorization Required');
-        executionScope.halt(callback);
     }
-    else {
-        executionScope.halt(callback, { code: 401, header: authHeader, attributes: attributes });
-    }
+    executionScope.errorResponse({ code: 401, header: authHeader, attributes: attributes });
+    executionScope.halt(callback);
   };
   return that;
 };

--- a/lib/authExecutionScope.js
+++ b/lib/authExecutionScope.js
@@ -10,15 +10,18 @@ AuthExecutionScope.prototype.success= function(user, callback) {
   this.executionResult.user= user;
   this.halt(callback);
 };
-AuthExecutionScope.prototype.halt= function(callback, errorResponse) {
+AuthExecutionScope.prototype.halt= function(callback) {
   this.executionResult.halted= true;
-  this.pass(callback, errorResponse);
+  this.pass(callback);
 };
-AuthExecutionScope.prototype.pass= function (callback, errorResponse) {
-  callback(errorResponse);
+AuthExecutionScope.prototype.pass= function (callback) {
+  callback();
 };
 AuthExecutionScope.prototype.redirect= function(response, url, callback) {
   response.writeHead(303, { 'Location': url });
   response.end('');
   this.halt(callback);
+};
+AuthExecutionScope.prototype.errorResponse = function(errorResponse) {
+    this.executionResult.errorResponse = errorResponse;
 };

--- a/lib/authExecutionScope.js
+++ b/lib/authExecutionScope.js
@@ -10,12 +10,12 @@ AuthExecutionScope.prototype.success= function(user, callback) {
   this.executionResult.user= user;
   this.halt(callback);
 };
-AuthExecutionScope.prototype.halt= function(callback) {
+AuthExecutionScope.prototype.halt= function(callback, errorResponse) {
   this.executionResult.halted= true;
-  this.pass(callback);
+  this.pass(callback, errorResponse);
 };
-AuthExecutionScope.prototype.pass= function(callback) {
-  callback();
+AuthExecutionScope.prototype.pass= function (callback, errorResponse) {
+  callback(errorResponse);
 };
 AuthExecutionScope.prototype.redirect= function(response, url, callback) {
   response.writeHead(303, { 'Location': url });

--- a/lib/authExecutionScope.js
+++ b/lib/authExecutionScope.js
@@ -22,6 +22,3 @@ AuthExecutionScope.prototype.redirect= function(response, url, callback) {
   response.end('');
   this.halt(callback);
 };
-AuthExecutionScope.prototype.errorResponse = function(errorResponse) {
-    this.executionResult.errorResponse = errorResponse;
-};

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,7 +88,8 @@ Auth= module.exports = function(optionsOrStrategy) {
           //TODO: DEFINE DEFAULT STRATEGY(IES)
         }
         if( isAuthenticated(req, scope) ) callback(null, true);
-        else strategyExecutor.authenticate(strategy, scope, req, res, function(error, executionResult){
+        else strategyExecutor.authenticate(strategy, scope, req, res, function (error, executionResult) {
+          req.getAuthDetails().errorResponse= executionResult.errorResponse;
           if(error) callback(error); // I really wish the plugins code logged errors.. 
           else {
             if( !executionResult.user ) callback(null,false)


### PR DESCRIPTION
Some application need to return specific error formats in the 400 or 401 response body, as well as allow for successful responses on conditional authentication. This change adds a global option 'isAutoRespond' which defaults to true. If set to false, HTTP schemes will not respond to an unauthenticated request. Instead, they will set req.getAuthDetails().errorResponse with the details of the HTTP code (400 or 401) and content of the WWW-Authenticate header.
