### PR TITLE
Updated twitter strategy to support callback

### DIFF
--- a/lib/auth.strategies/twitter.js
+++ b/lib/auth.strategies/twitter.js
@@ -16,7 +16,7 @@ Twitter= module.exports= function(options, server) {
   my._oAuth= new OAuth("http://twitter.com/oauth/request_token",
                          "http://twitter.com/oauth/access_token", 
                          options.consumerKey,  options.consumerSecret, 
-                         "1.0", null, "HMAC-SHA1");
+                         "1.0", options.callback || null, "HMAC-SHA1");
 
   // Give the strategy a name
   that.name  = options.name || "twitter";


### PR DESCRIPTION
Twitter strategy now supports oauth_callback using the options.callback like in other strategies. If no callback supplied, works how it always has.
