### PR TITLE
Added support for POST params in oauth parseParameters

### DIFF
--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -19,13 +19,20 @@ function parseParameters( method, headers, query, body ) {
     delete result.realm;
   }
 
-  //TODO: Figure out how to use post params....
+  // GET variables
   if( query ) {
     for(var key in query) {
       result[key] = query[key];
     }
   }
-  
+
+  // POST variables
+  if( body ) {
+    for(var key in body) {
+      result[key] = body[key];
+    }
+  }
+
   return result;
 }
 


### PR DESCRIPTION
Ciaran, I just added some code to support POST params which are needed to generate the calculatedSignature for an OAuth POST request.

Cheers,
Tony.
