### PR TITLE
Add LinkedIn and Yammer auth strategies.

### DIFF
--- a/lib/auth.strategies/linkedin.js
+++ b/lib/auth.strategies/linkedin.js
@@ -1,0 +1,91 @@
+/*!
+ * Copyright(c) 2010 Stephen Belanger <admin@stephenbelanger.com>
+ * MIT Licensed
+ */
+var OAuth = require("oauth").OAuth,
+	url = require("url"),
+	connect = require("connect"),
+	http = require('http');
+
+Linkedin = module.exports = function(options, server) {
+	options = options || {}
+	var that = {};
+	var my = {};
+
+	// Construct the internal OAuth client
+	my._oAuth = new OAuth(
+		"https://api.linkedin.com/uas/oauth/requestToken"
+		, "https://api.linkedin.com/uas/oauth/accessToken"
+		, options.consumerKey
+		, options.consumerSecret
+		, "1.0"
+		, options.callback || null
+		, "HMAC-SHA1"
+	);
+
+	// Give the strategy a name
+	that.name = options.name || "linkedin";
+	
+	// Build the authentication routes required 
+	that.setupRoutes= function(server) {
+		server.use('/', connect.router(function routes(app) {
+			app.get('/auth/linkedin_callback', function(req, res) {
+				req.authenticate([that.name], function(error, authenticated) {
+					res.writeHead(303, {
+						'Location': req.session.linkedin_redirect_url
+					});
+					res.end('');
+				});
+			});
+		}));
+	}
+
+	// Declare the method that actually does the authentication
+	that.authenticate = function(request, response, callback) {
+		//todo: if multiple connect middlewares were doing this, it would be more efficient to do it in the stack??
+		var parsedUrl = url.parse(request.url, true);
+
+		//todo: makw the call timeout ....
+		var self = this;
+		if (parsedUrl.query && parsedUrl.query.oauth_token && parsedUrl.query.oauth_verifier && request.session.auth["linkedin_oauth_token_secret"]) {
+			my._oAuth.getOAuthAccessToken(parsedUrl.query.oauth_token, request.session.auth["linkedin_oauth_token_secret"], parsedUrl.query.oauth_verifier, function(error, token, secret, params) {
+					if (error) {
+						callback(null);
+					} else {
+						request.session.auth["linkedin_oauth_token_secret"] = secret;
+						request.session.auth["linkedin_oauth_token"] = token;
+						
+						// Get user profile data.
+						my._oAuth.getProtectedResource("https://api.linkedin.com/v1/people/~", 'get', token, secret, function (error, data, response) {
+							if (error) {
+								self.fail(callback);
+							} else {
+								var result = JSON.parse(data);
+								var user = {
+									first_name: result.firstName
+									, last_name: result.lastName
+									, url: result.siteStandardProfileRequest.url
+									, headline: result.headline
+								};
+								self.executionResult.user = user; 
+								self.success(user, callback);
+							}
+						})
+					}
+			});
+		} else {
+			my._oAuth.getOAuthRequestToken(function(error, token, secret, auth_url, params) {
+				if (error) {
+					callback(null); // Ignore the error upstream, treat as validation failure.
+				} else {
+					request.session['linkedin_redirect_url'] = request.url;
+					request.session.auth["linkedin_oauth_token_secret"] = secret;
+					request.session.auth["linkedin_oauth_token"] = token;
+					self.redirect(response, "https://api.linkedin.com/uas/oauth/authorize?oauth_token=" + token, callback);
+				}
+			});
+		}
+	}	
+	return that;
+};
+

--- a/lib/auth.strategies/linkedin.js
+++ b/lib/auth.strategies/linkedin.js
@@ -56,7 +56,7 @@ Linkedin = module.exports = function(options, server) {
 						request.session.auth["linkedin_oauth_token"] = token;
 						
 						// Get user profile data.
-						my._oAuth.getProtectedResource("https://api.linkedin.com/v1/people/~", 'get', token, secret, function (error, data, response) {
+						my._oAuth.getProtectedResource("https://api.linkedin.com/v1/people/~", 'get', token, secret, {'x-li-format':'json'}, function (error, data, response) {
 							if (error) {
 								self.fail(callback);
 							} else {

--- a/lib/auth.strategies/openid.js
+++ b/lib/auth.strategies/openid.js
@@ -1,0 +1,57 @@
+/*!
+ * Copyright(c) 2011 Stephen Belanger <admin@stephenbelanger.com>
+ * 
+ * MIT Licensed
+ */
+var openid = require("openid"),
+	url = require("url"),
+	connect = require("connect"),
+	http = require('http'),
+	querystring = require('querystring');
+
+module.exports = function(options, server) {
+	options = options || {}
+	var that = {};
+	var my = {};
+	
+	// Generate OpenID relying party.
+	my._relyingParty = new openid.RelyingParty(options.callback, null, false, false, []);
+
+	// Give the strategy a name
+	that.name = options.name || "openid";
+
+	// Declare the method that actually does the authentication.
+	that.authenticate = function(request, response, callback) {
+		// Collect query info...
+		var parsedUrl = url.parse(request.url, true);
+		
+		// Get self reference.
+		var self = this;
+		
+		// Our identifier is in the query string, so we haven't authenticated yet.
+		if (parsedUrl.query.openid_identifier) {
+			request.session.openid_identifier = parsedUrl.query.openid_identifier;
+			// Resolve identifier, associate, and build authentication URL
+			my._relyingParty.authenticate(parsedUrl.query.openid_identifier, false, function(authUrl) {
+				if ( ! authUrl) {
+					callback(null);
+				} else {
+					self.redirect(response, authUrl, callback);
+				}
+			});
+		} else {
+			my._relyingParty.verifyAssertion(request, function(result) {
+				if ( ! result.authenticated) {
+					callback(null);
+				} else {
+					var user = {
+						identifier: result.claimedIdentifier
+					};
+					self.executionResult.user = user; 
+					self.success(user, callback);
+				}
+			});
+		}
+	}	
+	return that;
+};

--- a/lib/auth.strategies/yammer.js
+++ b/lib/auth.strategies/yammer.js
@@ -1,0 +1,85 @@
+/*!
+ * Copyright(c) 2010 Stephen Belanger <admin@stephenbelanger.com>
+ * MIT Licensed
+ */
+var OAuth = require("oauth").OAuth,
+	url = require("url"),
+	connect = require("connect"),
+	http = require('http');
+
+yammer = module.exports = function(options, server) {
+	options = options || {}
+	var that = {};
+	var my = {};
+
+	// Construct the internal OAuth client
+	my._oAuth = new OAuth(
+		"https://www.yammer.com/oauth/request_token"
+		, "https://www.yammer.com/oauth/access_token"
+		, options.consumerKey
+		, options.consumerSecret
+		, "1.0"
+		, options.callback || null
+		, "HMAC-SHA1"
+	);
+
+	// Give the strategy a name
+	that.name = options.name || "yammer";
+	
+	// Build the authentication routes required 
+	that.setupRoutes= function(server) {
+		server.use('/', connect.router(function routes(app) {
+			app.get('/auth/yammer_callback', function(req, res) {
+				req.authenticate([that.name], function(error, authenticated) {
+					res.writeHead(303, {
+						'Location': req.session.yammer_redirect_url
+					});
+					res.end('');
+				});
+			});
+		}));
+	}
+
+	// Declare the method that actually does the authentication
+	that.authenticate = function(request, response, callback) {
+		//todo: if multiple connect middlewares were doing this, it would be more efficient to do it in the stack??
+		var parsedUrl = url.parse(request.url, true);
+
+		//todo: makw the call timeout ....
+		var self = this;
+		if (parsedUrl.query && parsedUrl.query.oauth_token && parsedUrl.query.oauth_verifier && request.session.auth["yammer_oauth_token_secret"]) {
+			my._oAuth.getOAuthAccessToken(parsedUrl.query.oauth_token, request.session.auth["yammer_oauth_token_secret"], parsedUrl.query.oauth_verifier, function(error, token, secret, params) {
+					if (error) {
+						callback(null);
+					} else {
+						request.session.auth["yammer_oauth_token_secret"] = secret;
+						request.session.auth["yammer_oauth_token"] = token;
+						
+						// Get user profile data.
+						my._oAuth.getProtectedResource("https://www.yammer.com/api/v1/groups.json", 'get', token, secret, function (error, data, response) {
+							if (error) {
+								self.fail(callback);
+							} else {
+								var result = JSON.parse(data);
+								self.executionResult.user = result; 
+								self.success(result, callback);
+							}
+						})
+					}
+			});
+		} else {
+			my._oAuth.getOAuthRequestToken(function(error, token, secret, auth_url, params) {
+				if (error) {
+					callback(null); // Ignore the error upstream, treat as validation failure.
+				} else {
+					request.session['yammer_redirect_url'] = request.url;
+					request.session.auth["yammer_oauth_token_secret"] = secret;
+					request.session.auth["yammer_oauth_token"] = token;
+					self.redirect(response, "https://www.yammer.com/oauth/authorize?oauth_token=" + token, callback);
+				}
+			});
+		}
+	}	
+	return that;
+};
+


### PR DESCRIPTION
The LinkedIn strategy is dependent on the pull request I just made to node-oauth allowing custom headers. LinkedIn requires the x-li-format header to be set to json if you want to work with json data, otherwise it returns XML, which is a bit painful to deal with. >.>
