### PR TITLE
Make callback url optional for Facebook auth.

### DIFF
--- a/lib/auth.strategies/facebook.js
+++ b/lib/auth.strategies/facebook.js
@@ -73,6 +73,7 @@ Facebook= module.exports= function(options, server) {
       }
       else {
          request.session['facebook_redirect_url']= request.url;
+         my._redirectUri = my._redirectUri || 'http://' + request.headers.host + require('url').parse(request.url).pathname
          var redirectUrl= my._oAuth.getAuthorizeUrl({redirect_uri : my._redirectUri, scope: my.scope })
          self.redirect(response, redirectUrl, callback);
        }


### PR DESCRIPTION
Added line to make callback url optional. (sets to initial incoming request url if not specified).
Happy to add a test case as soon as the Facebook strategy has a spec. Also let me know if/where I should update the docs and examples.

Thanks,
Kav
