### PR TITLE
FB callback_url now optional

### DIFF
--- a/lib/auth.strategies/facebook.js
+++ b/lib/auth.strategies/facebook.js
@@ -7,7 +7,7 @@ var OAuth= require("oauth").OAuth2,
     connect = require("connect"),
     http = require('http');
 
-module.exports= function(options, server) {
+Facebook= module.exports= function(options, server) {
   options= options || {}
   var that= {};
   var my= {};
@@ -54,8 +54,10 @@ module.exports= function(options, server) {
         if( parsedUrl.query.error_reason == 'user_denied' ) {
           self._facebook_fail(callback);
         } else {
+          var redirectUri = my._redirectUri || 'http://' + request.headers.host + require('url').parse(request.url).pathname;
+          
           my._oAuth.getOAuthAccessToken(parsedUrl.query && parsedUrl.query.code ,
-                                       {redirect_uri: my._redirectUri}, function( error, access_token, refresh_token ){
+                                       {redirect_uri: redirectUri}, function( error, access_token, refresh_token ){
                                          if( error ) callback(error)
                                          else {
                                            request.session["access_token"]= access_token;
@@ -73,7 +75,8 @@ module.exports= function(options, server) {
       }
       else {
          request.session['facebook_redirect_url']= request.url;
-         var redirectUrl= my._oAuth.getAuthorizeUrl({redirect_uri : my._redirectUri, scope: my.scope })
+         var redirectUri = my._redirectUri || 'http://' + request.headers.host + require('url').parse(request.url).pathname;
+         var redirectUrl= my._oAuth.getAuthorizeUrl({redirect_uri : redirectUri, scope: my.scope });
          self.redirect(response, redirectUrl, callback);
        }
      }


### PR DESCRIPTION
Made FB redirect url optional. (Works this time, sorry about the brain fart last time). Been using this for a few weeks and it works like a charm. Happy to share the Express middleware code I use with it to achieve the onion layers people seem to keep complaining about.
