### PR TITLE
make sure base64EncodeChars, base64DecodeChars don't leak into the global scope

### DIFF
--- a/lib/auth.strategies/http/base64.js
+++ b/lib/auth.strategies/http/base64.js
@@ -2,6 +2,9 @@
  
 exports.encode = base64encode;
 exports.decode = base64decode;
+
+var base64EncodeChars, base64DecodeChars;
+
 this.chars = function( string ) {
   base64EncodeChars = string || "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
   base64DecodeChars = [];


### PR DESCRIPTION
Make sure base64EncodeChars, base64DecodeChars don't leak into the global scope.
We recently switched to use strict mode to prevent this kind of problems from happening https://developer.mozilla.org/en/JavaScript/Strict_mode
