### PR TITLE
Added pre-rfc dialect of OAuth to OAuth provider.

### DIFF
--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -44,7 +44,7 @@ exports.OAuthServices= function(provider) {
     Ensure the provider has the correct functions
   **/
   ['previousRequestToken', 'tokenByConsumer', 'applicationByConsumerKey', 'validToken', 'authenticateUser', 'generateRequestToken', 'generateAccessToken', 'cleanRequestTokens', 'validateNotReplay', 'associateTokenToUser', 'tokenByTokenAndVerifier', 'userIdByToken'].forEach(function(method) {
-    if(!(Object.prototype.toString.call(provider[method]) === "[object Function]")) throw Error("Data provider must provide the methods ['previousRequestToken', 'tokenByConsumer', 'applicationByConsumerKey', 'validToken', 'authenticateUser', 'generateRequestToken', 'generateAccessToken', 'cleanRequestTokens', 'validateNotReplay', 'associateTokenToUser', 'tokenByTokenAndVerifier']");
+    if(!(Object.prototype.toString.call(provider[method]) === "[object Function]")) throw Error("Data provider must provide the methods ['previousRequestToken', 'tokenByConsumer', 'applicationByConsumerKey', 'validToken', 'authenticateUser', 'generateRequestToken', 'generateAccessToken', 'cleanRequestTokens', 'validateNotReplay', 'associateTokenToUser', 'tokenByTokenAndVerifier', 'userIdByToken']");
   });  
 };
 
@@ -143,7 +143,7 @@ exports.OAuthServices.prototype.authorize= function(request, protocol, callback)
   var requestParameters= parseParameters(method, headers, query, request.body);
   if(requestParameters == null) { callback(new errors.OAuthBadRequestError("Missing required parameter"), null); return };  
   // Ensure correct parameters are available
-  if(!validateParameters(requestParameters, ['oauth_consumer_key', 'oauth_token', 
+  if(!validateParameters(requestParameters, ['oauth_consumer_key', //'oauth_token', 
                                              'oauth_signature_method', 'oauth_signature', 
                                              'oauth_timestamp', 'oauth_nonce'])) { 
     callback(new errors.OAuthBadRequestError("Missing required parameter"), null); 
@@ -204,7 +204,7 @@ exports.OAuthServices.prototype.fetchAuthorizationInformation = function(usernam
   });
 }
 
-exports.OAuthServices.prototype.requestToken= function(request, protocol, callback) {
+exports.OAuthServices.prototype.requestToken= function(request, protocol, dialect, callback) {
   var parsedUrl= url.parse(request.url, true);
   var method= request.method;
   var headers= request.headers;
@@ -214,41 +214,83 @@ exports.OAuthServices.prototype.requestToken= function(request, protocol, callba
   
   var requestParameters= parseParameters(method, headers, query, request.body);
   // Ensure correct parameters are available
-  if(!validateParameters(requestParameters, ['oauth_consumer_key', 'oauth_signature_method', 
-                                             'oauth_signature', 'oauth_timestamp', 
-                                             'oauth_nonce', 'oauth_callback'])) { 
-                                               
+  switch(dialect) {
+    case 'prerfc':
+      requiredParams= ['oauth_consumer_key', 'oauth_signature_method', 'oauth_signature',
+        'oauth_timestamp', 'oauth_nonce'];
+      break;
+    case '1.0a':
+    default:
+      requiredParams= ['oauth_consumer_key', 'oauth_signature_method', 'oauth_signature',
+        'oauth_timestamp', 'oauth_nonce', 'oauth_callback'];
+      break;
+  }
+
+  if(!validateParameters(requestParameters, requiredParams)) { 
     callback( new errors.OAuthBadRequestError("Missing required parameter"), null); 
     return 
   };    
 
-  // Make a note of this as it will screw stuff up later if we leave it in the parameters bag
+  // signature wasn't used for signature calculation...delete from the parameters bag
+  // but we need it later, so store it
   var oauth_signature= requestParameters['oauth_signature'];
   delete requestParameters['oauth_signature'];
   
   var self = this;
-  // Fetch the secret and token for the user
-  this.provider.applicationByConsumerKey(requestParameters['oauth_consumer_key'], function(err, user) {
+  // Fetch the secret and token for the passed oauth_consumer_key
+  this.provider.applicationByConsumerKey(requestParameters['oauth_consumer_key'], function(err, consumerRecord) {
     if(err) {
       callback(new errors.OAuthProviderError('Invalid Consumer Key'), null);        
-    } else {       
-      if(user.consumer_key == null || user.secret == null) { callback(new errors.OAuthProviderError("provider: applicationByConsumerKey must return a object with fields [consumer_key, secret]")); return;}
-      // Ensure we don't have any hanging consumer keys
-      self.provider.cleanRequestTokens(requestParameters['oauth_consumer_key'], function(err, result) {
-        // If we have a user for this consumer key let's calculate the signature
-        var oauthClient= new oauth.OAuth(null, null, requestParameters['oauth_consumer_key'], user.secret, null, null, 'HMAC-SHA1');
+    } else {
+      switch(dialect) {
+        case 'prerfc':
+          if(consumerRecord.consumer_key == null || consumerRecord.secret == null ||
+            consumerRecord.callback_url == null) {
+            callback(new errors.OAuthProviderError("provider: applicationByConsumerKey must " +
+              " return an object with fields [consumer_key, secret, callback_url]"));
+            return;
+          }
+          break;
+        case '1.0a':
+        default:
+          if(user.consumer_key == null || user.secret == null) {
+            callback(new errors.OAuthProviderError("provider: applicationByConsumerKey must " +
+            " return a object with fields [consumer_key, secret]"));
+            return;
+          }
+          break;
+      }
+                
+      // Ensure we don't have any hanging request tokens
+      self.provider.cleanRequestTokens(consumerRecord.consumer_key, function(err, result) {
+        var oauthClient= new oauth.OAuth(null, null, consumerRecord.consumer_key, consumerRecord.secret, null, null, 'HMAC-SHA1');
         parsedUrl.protocol= protocol+":";
         parsedUrl.host= host;
         var reconstructedUrl= url.format(parsedUrl);
         var reconstructedOauthParameters= oauthClient._normaliseRequestParams(requestParameters);
-        var calculatedSignature= oauthClient._getSignature(method, reconstructedUrl, reconstructedOauthParameters , user.token );
-        // Check if the signature is correct and return a request token
-        if(calculatedSignature == oauth_signature /*|| self.calculateSignatureGoogleWay(method, protocol, url, path, requestParameters, user.token, user.secret) == requestParameters.oauth_signature */) {
-          self.provider.generateRequestToken(requestParameters.oauth_consumer_key, requestParameters.oauth_callback, function(err, result) {
+        var calculatedSignature= oauthClient._getSignature(method, reconstructedUrl,
+          reconstructedOauthParameters, consumerRecord.token );
+        // Check signature on the request token request (generated by consumer), and return the request token.
+        if(calculatedSignature == oauth_signature) {
+          switch(dialect) {
+            case 'prerfc':
+              callbackUrl = consumerRecord.callback_url;
+              break;
+            case '1.0a':
+            default:
+              callbackUrl = requestParameters.oauth_callback;
+              break;
+          }
+
+          self.provider.generateRequestToken(consumerRecord.consumer_key, callbackUrl, function(err, result) {
             if(err) {
               callback(new errors.OAuthProviderError("internal error"), null);
             } else {
-              if(result.token == null || result.token_secret == null) { callback(new errors.OAuthProviderError("provider: generateRequestToken must return a object with fields [token, token_secret]"), null); return;}
+              if(result.token == null || result.token_secret == null) {
+                callback(new errors.OAuthProviderError("provider: generateRequestToken must return a " +
+                  "object with fields [token, token_secret]"), null);
+                return;
+              }
               result['oauth_callback_confirmed'] = true;
               callback(null, result);                
             }
@@ -257,7 +299,7 @@ exports.OAuthServices.prototype.requestToken= function(request, protocol, callba
           callback(new errors.OAuthUnauthorizedError("Invalid signature"), null);          
         }
      }); 
-   }
+    }
   });
 
   /**

--- a/lib/auth.strategies/oauth/oauth.js
+++ b/lib/auth.strategies/oauth/oauth.js
@@ -2,7 +2,7 @@
  * Copyright(c) 2010 Ciaran Jessup <ciaranj@gmail.com>
  * MIT Licensed
  * 
- * Provides an OAuth 1.0A authentication strategy
+ * Provides an OAuth authentication strategy (defaults to OAuth 1.0a)
  */
 var connect= require("connect")
    ,OAuthServices= require('./_oauthservices').OAuthServices;
@@ -13,6 +13,7 @@ var connect= require("connect")
   *
   * Options:
   *
+  *   - dialect                  'defaults to '1.0a' for OAuth 1.0a, or 'prerfc' for pre-RFC OAuth 1.0
   *   - request_token_url        'web path for the request token url endpoint, default: /oauth/request_token' (get/post)
   *   - authorize_url            'web path for the authorize form, default: /oauth/authorize' (get/post)
   *   - access_token_url         'web path for the access token url endpoint, default: /oauth/access_token' (get/post)
@@ -34,6 +35,7 @@ module.exports= function(options) {
   var my= {};
   
   // Ensure we have default values and legal options
+  my['dialect']= options['dialect'] || '1.0a';
   my['request_token_url']= options['request_token_url'] || '/oauth/request_token';
   my['authorize_url']=     options['authorize_url']     || '/oauth/authorize';
   my['access_token_url']=  options['access_token_url']  || '/oauth/access_token';
@@ -71,7 +73,7 @@ module.exports= function(options) {
   }
   
   var requestTokenMethod= function(req, res) {
-    my['oauth_service'].requestToken(req, my['oauth_protocol'], function(error, result) {
+    my['oauth_service'].requestToken(req, my['oauth_protocol'], my['dialect'], function(error, result) {
       if( error ) {
         res.writeHead(error.statusCode, {'Content-Type': 'text/plain'})
         res.end(error.message);


### PR DESCRIPTION
Some Google properties (Gadget Containers) use a pre-rfc version of the OAuth protocol, which predates the requirement for an oauth_callback parameter (among others). This commit parameterizes the OAuth 1.0a provider code to support this behavior when a switch is passed on initialization. The change is fully backward-compatible, and won't break any existing code.
