### PR TITLE
Added checking for 'error' query string parameter in github callback

### DIFF
--- a/lib/auth.strategies/github.js
+++ b/lib/auth.strategies/github.js
@@ -69,6 +69,10 @@ module.exports= function(options, server) {
                                          }
                                        });
       }
+      else if( parsedUrl.query && parsedUrl.query.error ) {
+        request.getAuthDetails()['github_login_attempt_failed'] = true;
+        self.fail(callback);
+      }     
       else {
          request.session['github_redirect_url']= request.url;
          var redirectUrl= my._oAuth.getAuthorizeUrl({redirect_uri : my._redirectUri, scope: my.scope })


### PR DESCRIPTION
When a user denies authorization using github, github makes a callback of the form:

http://myapp.com/auth/github_callback?error=user_denied

I added checking for this error query string to the github strategy.

Thanks for this great library!
