### PR TITLE
Alternate signature methods

### DIFF
--- a/examples/oauthapp.js
+++ b/examples/oauthapp.js
@@ -1,5 +1,5 @@
 var connect = require('connect');   
-var MemoryStore = require('connect/middleware/session/memory');
+//var MemoryStore = require('connect/middleware/session/memory');
 var auth= require('../lib');
 var url= require('url');
 var OAuthDataProvider= require('./in_memory_oauth_data_provider').OAuthDataProvider;
@@ -93,7 +93,7 @@ var authorizationFinishedProvider = function(err, req, res, result) {
 }
 
 var server= connect.createServer( 
-                      connect.bodyDecoder(),
+                      connect.bodyParser(),
                       auth( [
                             auth.Oauth({oauth_provider: new OAuthDataProvider({  applications:[{title:'Test', description:'Test App', consumer_key:"JiYmll7CX3AXDgasnnIDeg",secret:"mWPBRK5kG2Tkthuf5zRV1jYWOEwnjI6xs3QVRqOOg"}]
                                                                                , users:[{username:'foo', password:'bar'}] }),

--- a/examples/oauthapp_2legged.js
+++ b/examples/oauthapp_2legged.js
@@ -1,0 +1,30 @@
+var connect = require('connect');   
+var auth= require('../lib');
+var url= require('url');
+var OAuthDataProvider= require('./in_memory_oauth_data_provider').OAuthDataProvider;
+function routes(app) {
+  app.get ('/fetch/unicorns', function(req, res, params) {
+    req.authenticate(['oauth'], function(error, authenticated) { 
+        if( authenticated ) {
+          res.writeHead(200, {'Content-Type': 'text/plain'})
+          res.end('The unicorns fly free tonight');
+        } 
+        else {
+          res.writeHead(401, {'Content-Type': 'text/plain'})
+          res.end('Doubt you\'ll ever see this.');
+        }
+    });
+  });
+}
+
+var server= connect.createServer( 
+                      connect.bodyParser(),
+                      auth( [
+                            auth.Oauth({oauth_provider: new OAuthDataProvider({  applications:[{title:'Test', description:'Test App', consumer_key:"JiYmll7CX3AXDgasnnIDeg",secret:"mWPBRK5kG2Tkthuf5zRV1jYWOEwnjI6xs3QVRqOOg"}]}),
+                                        authenticate_provider: null,
+                                        authorize_provider: null,
+                                        authorization_finished_provider: null
+                                       })
+                            ]), 
+                      connect.router(routes));
+server.listen(3000);

--- a/examples/oauthclient_2legged.js
+++ b/examples/oauthclient_2legged.js
@@ -1,0 +1,13 @@
+var OAuth= require('oauth').OAuth;
+
+var oa= new OAuth("http://localhost:3000/oauth/request_token",
+                  "http://localhost:3000/oauth/access_token",
+                  "JiYmll7CX3AXDgasnnIDeg",
+                  "mWPBRK5kG2Tkthuf5zRV1jYWOEwnjI6xs3QVRqOOg",
+                  "1.0",
+                  null,
+                  "HMAC-SHA1")
+
+oa.getProtectedResource("http://localhost:3000/fetch/unicorns", "GET", '', '',  function (error, data, response) {
+    console.log(data);
+});

--- a/examples/oauthclientapp.js
+++ b/examples/oauthclientapp.js
@@ -1,11 +1,11 @@
 var connect = require('connect');   
 var url= require('url')
-var MemoryStore = require('connect/middleware/session/memory');
+//var MemoryStore = require('connect/middleware/session/memory');
 
 // We let the example run without npm, by setting up the require paths
 // so the node-oauth submodule inside of git is used.  You do *NOT*
 // need to bother with this line if you're using npm ...
-require.paths.unshift('support')
+//require.paths.unshift('support')
 var OAuth= require('oauth').OAuth;
 var oa= new OAuth("http://localhost:3000/oauth/request_token",
                  "http://localhost:3000/oauth/access_token", 
@@ -37,8 +37,8 @@ function routes(app) {
 }
 
 var server= connect.createServer( 
-                      connect.cookieDecoder(), 
-                      connect.session({key:'consumer'}),
+                      connect.cookieParser(),
+                      connect.session({secret:'consumer'}),
 /*                      connect.session({ store: new MemoryStore({ reapInterval: -1 }) }), */
                       connect.router(routes));
 server.listen(4000);

--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -80,6 +80,12 @@ exports.OAuthServices.prototype.accessToken= function(request, protocol, callbac
   // Make a note of this as it will screw stuff up later if we leave it in the parameters bag
   var oauth_signature= requestParameters['oauth_signature'];
   delete requestParameters['oauth_signature'];
+
+  // Reject non-HMAC-SHA1 and non-PLAINTEXT signature_methods
+  if (requestParameters['oauth_signature_method'] != 'HMAC-SHA1' &&
+    requestParameters['oauth_signature_method'] != 'PLAINTEXT') {
+    return callback(new errors.OAuthProviderError('Invalid Signature Method'));
+  }
   
   var self= this;    
   // Fetch the secret and token for the user
@@ -102,7 +108,7 @@ exports.OAuthServices.prototype.accessToken= function(request, protocol, callbac
                 callback(new errors.OAuthUnauthorizedError("Invalid / expired Token"), null);
               } else {
                 // If we have a user for this consumer key let's calculate the signature
-                var oauthClient= new oauth.OAuth(null, null, requestParameters['oauth_consumer_key'], user.secret, null, null, 'HMAC-SHA1');
+                var oauthClient= new oauth.OAuth(null, null, requestParameters['oauth_consumer_key'], user.secret, null, null, requestParameters['oauth_signature_method']);
                 parsedUrl.protocol= protocol+":";
                 parsedUrl.host= host;
                 var reconstructedUrl= url.format(parsedUrl);
@@ -168,6 +174,12 @@ exports.OAuthServices.prototype.authorize= function(request, protocol, callback)
   // Make a note of this as it will screw stuff up later if we leave it in the parameters bag
   var oauth_signature= requestParameters['oauth_signature'];
   delete requestParameters['oauth_signature'];
+
+  // Reject non-HMAC-SHA1 and non-PLAINTEXT signature_methods
+  if (requestParameters['oauth_signature_method'] != 'HMAC-SHA1' &&
+    requestParameters['oauth_signature_method'] != 'PLAINTEXT') {
+    return callback(new errors.OAuthProviderError('Invalid Signature Method'));
+  }
   
   var self = this; 
   
@@ -191,7 +203,7 @@ exports.OAuthServices.prototype.authorize= function(request, protocol, callback)
 
   var checkSignature = function(requestParameters, application, token, next) {
     // If we have a application for this consumer key let's calculate the signature
-    var oauthClient= new oauth.OAuth(null, null, requestParameters['oauth_consumer_key'], application.secret, null, null, 'HMAC-SHA1');
+    var oauthClient= new oauth.OAuth(null, null, requestParameters['oauth_consumer_key'], application.secret, null, null, requestParameters['oauth_signature_method']);
     parsedUrl.protocol= protocol+":";
     parsedUrl.host= host;
     var reconstructedUrl= url.format(parsedUrl);
@@ -280,6 +292,12 @@ exports.OAuthServices.prototype.requestToken= function(request, protocol, callba
   // Make a note of this as it will screw stuff up later if we leave it in the parameters bag
   var oauth_signature= requestParameters['oauth_signature'];
   delete requestParameters['oauth_signature'];
+
+  // Reject non-HMAC-SHA1 and non-PLAINTEXT signature_methods
+  if (requestParameters['oauth_signature_method'] != 'HMAC-SHA1' &&
+    requestParameters['oauth_signature_method'] != 'PLAINTEXT') {
+    return callback(new errors.OAuthProviderError('Invalid Signature Method'));
+  }
   
   var self = this;
   // Fetch the secret and token for the user
@@ -291,7 +309,7 @@ exports.OAuthServices.prototype.requestToken= function(request, protocol, callba
       // Ensure we don't have any hanging consumer keys
       self.provider.cleanRequestTokens(requestParameters['oauth_consumer_key'], function(err, result) {
         // If we have a user for this consumer key let's calculate the signature
-        var oauthClient= new oauth.OAuth(null, null, requestParameters['oauth_consumer_key'], user.secret, null, null, 'HMAC-SHA1');
+        var oauthClient= new oauth.OAuth(null, null, requestParameters['oauth_consumer_key'], user.secret, null, null, requestParameters['oauth_signature_method']);
         parsedUrl.protocol= protocol+":";
         parsedUrl.host= host;
         var reconstructedUrl= url.format(parsedUrl);

--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -38,8 +38,14 @@ function validateParameters(parameters, requiredParameters) {
   return legalParameters;
 }
 
-exports.OAuthServices= function(provider) {
+exports.OAuthServices= function(provider, legs) {
   this.provider= provider;
+  if (legs) {
+    this.legs = legs;
+  }
+  else {
+    this.legs = 3;
+  }
   /**
     Ensure the provider has the correct functions
   **/

--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -40,17 +40,22 @@ function validateParameters(parameters, requiredParameters) {
 
 exports.OAuthServices= function(provider, legs) {
   this.provider= provider;
+  var requiredMethods = ['applicationByConsumerKey','validateNotReplay'];
   if (legs) {
     this.legs = legs;
   }
   else {
     this.legs = 3;
   }
+
+  if (this.legs == 3) {
+    requiredMethods = requiredMethods.concat(['previousRequestToken', 'tokenByConsumer', 'validToken', 'authenticateUser', 'generateRequestToken', 'generateAccessToken', 'cleanRequestTokens', 'associateTokenToUser', 'tokenByTokenAndVerifier', 'userIdByToken']);
+  }
   /**
     Ensure the provider has the correct functions
   **/
-  ['previousRequestToken', 'tokenByConsumer', 'applicationByConsumerKey', 'validToken', 'authenticateUser', 'generateRequestToken', 'generateAccessToken', 'cleanRequestTokens', 'validateNotReplay', 'associateTokenToUser', 'tokenByTokenAndVerifier', 'userIdByToken'].forEach(function(method) {
-    if(!(Object.prototype.toString.call(provider[method]) === "[object Function]")) throw Error("Data provider must provide the methods ['previousRequestToken', 'tokenByConsumer', 'applicationByConsumerKey', 'validToken', 'authenticateUser', 'generateRequestToken', 'generateAccessToken', 'cleanRequestTokens', 'validateNotReplay', 'associateTokenToUser', 'tokenByTokenAndVerifier']");
+  requiredMethods.forEach(function(method) {
+    if(!(Object.prototype.toString.call(provider[method]) === "[object Function]")) throw Error("Data provider must provide the methods [" + requiredMethods.join(', ') + "]");
   });  
 };
 

--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -166,42 +166,81 @@ exports.OAuthServices.prototype.authorize= function(request, protocol, callback)
   
   var self = this; 
   
+  // Given all the requestParameters and the next step function, error out if the a replay is detected
+  var validateNotReplay = function(requestParameters, next) {
+    self.provider.validateNotReplay(requestParameters.oauth_token, requestParameters.oauth_timestamp, requestParameters.oauth_nonce, function(err, result) {
+      if(err) {
+        callback(new errors.OAuthUnauthorizedError('Invalid / used nonce'), null);
+      } else {
+        next();
+      }
+    });
+  };
+
+  var getApplicationByConsumerKey = function(consumer_key, next) {
+    self.provider.applicationByConsumerKey(consumer_key, function(err, application) {
+      if(application.consumer_key == null || application.secret == null) { callback(new errors.OAuthProviderError("provider: applicationByConsumerKey must return a object with fields [consumer_key, secret]"), null); return;}
+      next(application);
+    });
+  };
+
+  var checkSignature = function(requestParameters, application, token, next) {
+    // If we have a application for this consumer key let's calculate the signature
+    var oauthClient= new oauth.OAuth(null, null, requestParameters['oauth_consumer_key'], application.secret, null, null, 'HMAC-SHA1');
+    parsedUrl.protocol= protocol+":";
+    parsedUrl.host= host;
+    var reconstructedUrl= url.format(parsedUrl);
+    var reconstructedOauthParameters= oauthClient._normaliseRequestParams(requestParameters);
+    var calculatedSignature= oauthClient._getSignature(method, reconstructedUrl, reconstructedOauthParameters , token ? token.token_secret : null);
+    
+    // Check if the signature is correct and return a access token
+    if(calculatedSignature == oauth_signature /*|| self.calculateSignatureGoogleWay(method, protocol, url, path, requestParameters, token.token_secret, application.secret) == requestParameters.oauth_signature*/) {
+      return next();
+    } else {
+      callback(new errors.OAuthBadRequestError("Invalid signature"), null);
+    }          
+  };
+  //
   // Check if token is valid
-  self.provider.validToken(requestParameters.oauth_token, function(err, token) {
-    if(err) {
-      callback(new errors.OAuthProviderError('Invalid / expired Token'), null);        
-    } else {                
-      if(token.access_token == null || token.token_secret == null) { callback(new errors.OAuthProviderError("provider: validToken must return a object with fields [access_token, token_secret]"), null); return;}
-      self.provider.validateNotReplay(requestParameters.oauth_token, requestParameters.oauth_timestamp, requestParameters.oauth_nonce, function(err, result) {
-        if(err) {
-          callback(new errors.OAuthUnauthorizedError('Invalid / used nonce'), null);
-        } else {
-          self.provider.applicationByConsumerKey(token.consumer_key, function(err, user) {
-            if(user.consumer_key == null || user.secret == null) { callback(new errors.OAuthProviderError("provider: applicationByConsumerKey must return a object with fields [token, secret]"), null); return;}
-            // If we have a user for this consumer key let's calculate the signature
-            var oauthClient= new oauth.OAuth(null, null, requestParameters['oauth_consumer_key'], user.secret, null, null, 'HMAC-SHA1');
-            parsedUrl.protocol= protocol+":";
-            parsedUrl.host= host;
-            var reconstructedUrl= url.format(parsedUrl);
-            var reconstructedOauthParameters= oauthClient._normaliseRequestParams(requestParameters);
-            var calculatedSignature= oauthClient._getSignature(method, reconstructedUrl, reconstructedOauthParameters ,  token.token_secret );
-            
-            // Check if the signature is correct and return a access token
-            if(calculatedSignature == oauth_signature /*|| self.calculateSignatureGoogleWay(method, protocol, url, path, requestParameters, token.token_secret, user.secret) == requestParameters.oauth_signature*/) {
+  if (this.legs == 3) {
+    // If token is valid
+    self.provider.validToken(requestParameters.oauth_token, function(err, token) {
+      if(err) {
+        callback(new errors.OAuthProviderError('Invalid / expired Token'), null);        
+      } else {                
+        if(token.access_token == null || token.token_secret == null) { callback(new errors.OAuthProviderError("provider: validToken must return a object with fields [access_token, token_secret]"), null); return;}
+        // And the request is not a replay request
+        validateNotReplay(requestParameters, function() {
+          // Get the application by its consumer key
+          getApplicationByConsumerKey(token.consumer_key, function(application) {
+            // Make sure the signature of the request is valid
+            checkSignature(requestParameters, application, token, function() {
               // Fetch the user id to pass back
               self.provider.userIdByToken(requestParameters.oauth_token, function(err, doc) {
                 if(doc.id == null) { callback(new errors.OAuthProviderError("provider: userIdByToken must return a object with fields [id]"), null); return;}
                 // Return the user id to the calling function
                 callback(null, doc);                
               });
-            } else {
-              callback(new errors.OAuthBadRequestError("Invalid signature"), null);
-            }          
+            });
           });
-        }
+        });
+      }
+    });
+  }
+  else {
+    // This is a 2-legged oauth request
+    // There is no token, only an application (so the consumer_key will be the id)
+
+    // Make sure the request is not a replay
+    validateNotReplay(requestParameters, function() {
+      getApplicationByConsumerKey(requestParameters['oauth_consumer_key'], function(application) {
+        checkSignature(requestParameters, application, null, function() {
+          // Return the application consumer key to the calling function
+          callback(null, {id: application.consumer_key});
+        });
       });
-    }
-  });
+    });
+  }
 };
 
 /**

--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -149,9 +149,14 @@ exports.OAuthServices.prototype.authorize= function(request, protocol, callback)
   var requestParameters= parseParameters(method, headers, query, request.body);
   if(requestParameters == null) { callback(new errors.OAuthBadRequestError("Missing required parameter"), null); return };  
   // Ensure correct parameters are available
-  if(!validateParameters(requestParameters, ['oauth_consumer_key', 'oauth_token', 
-                                             'oauth_signature_method', 'oauth_signature', 
-                                             'oauth_timestamp', 'oauth_nonce'])) { 
+  var paramsToValidate = ['oauth_consumer_key',
+                          'oauth_signature_method', 'oauth_signature', 
+                          'oauth_timestamp', 'oauth_nonce'];
+  if (this.legs == 3) {
+    paramsToValidate.push('oauth_token');
+  }
+
+  if(!validateParameters(requestParameters, paramsToValidate)) { 
     callback(new errors.OAuthBadRequestError("Missing required parameter"), null); 
     return 
   };    

--- a/lib/auth.strategies/oauth/oauth.js
+++ b/lib/auth.strategies/oauth/oauth.js
@@ -32,6 +32,7 @@ module.exports= function(options) {
   options= options || {};
   that.name= options.name || "oauth";
   var my= {};
+  var legs = null;
   
   // Ensure we have default values and legal options
   my['request_token_url']= options['request_token_url'] || '/oauth/request_token';
@@ -46,14 +47,26 @@ module.exports= function(options) {
   my['oauth_provider']= options['oauth_provider'];
   my['authorization_finished_provider']= options['authorization_finished_provider'];
 
-  // Both authorize handler and oauth provider must be provided
-  if(my['authenticate_provider'] == null) throw Error("No Authentication provider provided");
-  if(my['authorize_provider'] == null) throw Error("No Authorization provider provided");
+  // If authorize handlers are null, we are using 2-legged auth
+  // Oauth provider must be provided
   if(!my['oauth_provider'] ) throw Error("No OAuth provider provided");
-  if(my['authorization_finished_provider'] == null) throw Error("No finished authentication provider provided");
+  // We must either receive all providers or none
+  if (my['authenticate_provider'] == null &&
+      my['authorize_provider'] == null &&
+      my['authorization_finished_provider'] == null) {
+    legs = 2;
+  }
+  else if (my['authenticate_provider'] != null &&
+          my['authorize_provider'] != null &&
+          my['authorization_finished_provider'] != null) {
+    legs = 3;
+  }
+  else {
+    throw Error("Either provide authenticate_provider, authorize_provider, and authorization_finished_provider or provide none of them");
+  }
 
   // Set up the OAuth provider and data source
-  my['oauth_service'] = new OAuthServices(my['oauth_provider']);
+  my['oauth_service'] = new OAuthServices(my['oauth_provider'], legs);
 
   that.authenticate= function(req, res, callback) {
       var self= this;
@@ -70,86 +83,89 @@ module.exports= function(options) {
       });
   }
   
-  var requestTokenMethod= function(req, res) {
-    my['oauth_service'].requestToken(req, my['oauth_protocol'], function(error, result) {
-      if( error ) {
-        res.writeHead(error.statusCode, {'Content-Type': 'text/plain'})
-        res.end(error.message);
-      }
-      else {
-        res.writeHead(200, {'Content-Type': 'text/plain'})
-        res.end(["oauth_token=" + result["token"], "oauth_token_secret=" + result["token_secret"], "oauth_callback_confirmed=" + result["oauth_callback_confirmed"]].join("&"));
-      }
-    });
-  }
-
-  var accessTokenMethod= function(req, res) {
-    my['oauth_service'].accessToken(req, my['oauth_protocol'], function(error, result) {
-      if( error ) {
-        res.writeHead(error.statusCode, {'Content-Type': 'text/plain'})
-        res.end(error.message);
-      }
-      else {
-        res.writeHead(200, {'Content-Type': 'text/plain'})
-        res.end(["oauth_token=" + result["access_token"], "oauth_token_secret=" + result["token_secret"]].join("&"));
-      }
-    });
-  }
-
-  // Build the authentication routes required 
-  that.setupRoutes= function(server) {
-    server.use('/', connect.router(function routes(app){
-      app.post(my['request_token_url'], requestTokenMethod);      
-      app.get(my['request_token_url'], requestTokenMethod);
-      app.post(my['access_token_url'], accessTokenMethod);      
-      app.get(my['access_token_url'], accessTokenMethod);
-    
-      // Should render the form that allows users to authenticate themselves 
-      app.get(my['authorize_url'], my['authenticate_provider'] );
-
-      // Handles the post from the authentication form.
-      app.post(my['authorize_url'], function(req, res) {
-        var self = this;
-        
-        if(req.body['verifier'] == null) {
-          my['oauth_service'].authenticateUser(req.body['username'], req.body['password'], req.body['oauth_token'], function(err, result) {                       
-            if(err) { 
-              // Delegate to the function of the user
-              my.authorize_provider.call(self, err, req, res, false, {token:req.body['oauth_token']});
-            } else {
-              // Fetch the needed data
-              my['oauth_service'].fetchAuthorizationInformation(req.body['username'], result.token, function(err, application, user) {
-                // Signal callback about finish authorization
-                my.authorize_provider.call(self, null, req, res, true, result, application, user);
-              });
-            }          
-          });          
-        } else {
-          var oauth_token= req.body['oauth_token'];
-          var verifier= req.body['verifier'];
-          
-          // Check if there is an entry for this token and verifier          
-          my['oauth_service'].verifyToken(oauth_token, verifier, function(err, result) {
-            if(err) {
-              // Delegate to the function of the user
-              my.authorize_provider.call(self, err, req, res, false, {token:oauth_token});              
-            } else {
-              if(result.callback != null && result.callback != "oob") {
-                var callback = result.callback;
-                // Correctly add the tokens if the callback has a ? allready
-                var redirect_url = callback.match(/\?/) != null ? "&oauth_token=" + result.token + "&oauth_verifier=" + result.verifier : "?oauth_token=" + result.token + "&oauth_verifier=" + result.verifier;
-                // Signal that a redirect is in order after finished process
-                res.writeHead(303, { 'Location': result.callback + redirect_url });
-                res.end('');
-                
-              } else {
-                my.authorization_finished_provider.call(self, err, req, res, result);
-              }             
-            }
-          });
+  // If we are using 2-legged auth, we don't need anything to do with request tokens
+  if (legs == 3) {
+    var requestTokenMethod= function(req, res) {
+      my['oauth_service'].requestToken(req, my['oauth_protocol'], function(error, result) {
+        if( error ) {
+          res.writeHead(error.statusCode, {'Content-Type': 'text/plain'})
+          res.end(error.message);
         }
-      }); 
-    }));
-  }  
+        else {
+          res.writeHead(200, {'Content-Type': 'text/plain'})
+          res.end(["oauth_token=" + result["token"], "oauth_token_secret=" + result["token_secret"], "oauth_callback_confirmed=" + result["oauth_callback_confirmed"]].join("&"));
+        }
+      });
+    }
+
+    var accessTokenMethod= function(req, res) {
+      my['oauth_service'].accessToken(req, my['oauth_protocol'], function(error, result) {
+        if( error ) {
+          res.writeHead(error.statusCode, {'Content-Type': 'text/plain'})
+          res.end(error.message);
+        }
+        else {
+          res.writeHead(200, {'Content-Type': 'text/plain'})
+          res.end(["oauth_token=" + result["access_token"], "oauth_token_secret=" + result["token_secret"]].join("&"));
+        }
+      });
+    }
+
+    // Build the authentication routes required 
+    that.setupRoutes= function(server) {
+      server.use('/', connect.router(function routes(app){
+        app.post(my['request_token_url'], requestTokenMethod);      
+        app.get(my['request_token_url'], requestTokenMethod);
+        app.post(my['access_token_url'], accessTokenMethod);      
+        app.get(my['access_token_url'], accessTokenMethod);
+      
+        // Should render the form that allows users to authenticate themselves 
+        app.get(my['authorize_url'], my['authenticate_provider'] );
+
+        // Handles the post from the authentication form.
+        app.post(my['authorize_url'], function(req, res) {
+          var self = this;
+          
+          if(req.body['verifier'] == null) {
+            my['oauth_service'].authenticateUser(req.body['username'], req.body['password'], req.body['oauth_token'], function(err, result) {                       
+              if(err) { 
+                // Delegate to the function of the user
+                my.authorize_provider.call(self, err, req, res, false, {token:req.body['oauth_token']});
+              } else {
+                // Fetch the needed data
+                my['oauth_service'].fetchAuthorizationInformation(req.body['username'], result.token, function(err, application, user) {
+                  // Signal callback about finish authorization
+                  my.authorize_provider.call(self, null, req, res, true, result, application, user);
+                });
+              }          
+            });          
+          } else {
+            var oauth_token= req.body['oauth_token'];
+            var verifier= req.body['verifier'];
+            
+            // Check if there is an entry for this token and verifier          
+            my['oauth_service'].verifyToken(oauth_token, verifier, function(err, result) {
+              if(err) {
+                // Delegate to the function of the user
+                my.authorize_provider.call(self, err, req, res, false, {token:oauth_token});              
+              } else {
+                if(result.callback != null && result.callback != "oob") {
+                  var callback = result.callback;
+                  // Correctly add the tokens if the callback has a ? allready
+                  var redirect_url = callback.match(/\?/) != null ? "&oauth_token=" + result.token + "&oauth_verifier=" + result.verifier : "?oauth_token=" + result.token + "&oauth_verifier=" + result.verifier;
+                  // Signal that a redirect is in order after finished process
+                  res.writeHead(303, { 'Location': result.callback + redirect_url });
+                  res.end('');
+                  
+                } else {
+                  my.authorization_finished_provider.call(self, err, req, res, result);
+                }             
+              }
+            });
+          }
+        }); 
+      }));
+    }  
+  }
   return that;
 };


### PR DESCRIPTION
This patch piggybacks on my 2-legged oauth patches.

It detects if the signature_method passed is HMAC-SHA1 or PLAINTEXT and then accepts either one when doing a signature verification.
