### PR TITLE
Need explicit requirement for connect.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "directories" : { "lib" : "./lib" },
   "devDependencies" : { "expresso": "0.7.7" },
   "dependencies" : {
-      "connect": ">= 1.4.3"
+      "connect": "1.8.5"
      , "oauth": ">= 0.9.4"
      , "openid": "0.3.1"
   },


### PR DESCRIPTION
Now that connect has just been upgraded to 2.0 this library needs to be tested for forwards compatibility. I have set the connect requirement explicitly to make sure it does not break when doing an npm install.
