### PR TITLE
Only consider body attributes as parameters if Content-Type is applicati...

### DIFF
--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -27,7 +27,7 @@ function parseParameters( method, headers, query, body ) {
   }
 
   // POST variables
-  if( body ) {
+  if(body && headers['content-type'] === 'application/x-www-form-urlencoded') {
     for(var key in body) {
       result[key] = body[key];
     }


### PR DESCRIPTION
...on/x-www-form-urlencoded

Fixes Issue #91.

We only consider body attributes as parameters if they're actually
parameters per http://tools.ietf.org/html/rfc5849#section-3.4.1.3.
