### PR TITLE
verifyToken was removed during a refactor

### DIFF
--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -338,14 +338,13 @@ exports.OAuthServices.prototype.requestToken= function(request, protocol, callba
      }); 
    }
   });
-
-  /**
-    Verify if a token exists using the verifier number and the oauth_otken
-  **/
+};
+/**
+  Verify if a token exists using the verifier number and the oauth_otken
+**/
 exports.OAuthServices.prototype.verifyToken = function(token, verifier, callback) {
-    this.provider.tokenByTokenAndVerifier(token, verifier, function(err, token) {
-      if(token.token == null || token.verifier == null) { callback(new errors.OAuthProviderError("provider: tokenByTokenAndVerifier must return a token object with fields [token, verifier]"), null); return;}
-      callback(err, token);
-    });
-  }  
+  this.provider.tokenByTokenAndVerifier(token, verifier, function(err, token) {
+    if(token.token == null || token.verifier == null) { callback(new errors.OAuthProviderError("provider: tokenByTokenAndVerifier must return a token object with fields [token, verifier]"), null); return;}
+    callback(err, token);
+  });
 };


### PR DESCRIPTION
During the changes for 2-legged oauth, a refactor (through no fault of mine, mind you ;) ) put the verifyToken method inside the requestToken method.  This breaks 3-legged oauth for everyone using it.

In this patch I also changed the indent of verifyToken to reflect where it actually should be in the code.
