### PR TITLE
Add tokenByTokenAndConsumer() to allow multiple request tokens per consu...

### DIFF
--- a/examples/in_memory_oauth_data_provider.js
+++ b/examples/in_memory_oauth_data_provider.js
@@ -36,9 +36,9 @@ OAuthDataProvider.prototype.previousRequestToken = function(token, callback) {
   callback(null, token);
 }
 
-OAuthDataProvider.prototype.tokenByConsumer = function(consumerKey, callback) {
+OAuthDataProvider.prototype.tokenByTokenAndConsumer = function(token, consumerKey, callback) {
   for(var key in this.oauth_users_request_tokens) {
-    if( this.oauth_users_request_tokens[key] && this.oauth_users_request_tokens[key].consumer_key == consumerKey ) {
+    if( this.oauth_users_request_tokens[key] && this.oauth_users_request_tokens[key].consumer_key == consumerKey && this.oauth_users_request_tokens[key].token == token ) {
       callback(null, this.oauth_users_request_tokens[key]);
       return;
     }

--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -56,14 +56,30 @@ exports.OAuthServices= function(provider, legs) {
   }
 
   if (this.legs == 3) {
-    requiredMethods = requiredMethods.concat(['previousRequestToken', 'tokenByConsumer', 'validToken', 'authenticateUser', 'generateRequestToken', 'generateAccessToken', 'cleanRequestTokens', 'associateTokenToUser', 'tokenByTokenAndVerifier', 'userIdByToken']);
+    requiredMethods = requiredMethods.concat(['previousRequestToken', 'validToken', 'authenticateUser', 'generateRequestToken', 'generateAccessToken', 'cleanRequestTokens', 'associateTokenToUser', 'tokenByTokenAndVerifier', 'userIdByToken']);
   }
   /**
     Ensure the provider has the correct functions
   **/
   requiredMethods.forEach(function(method) {
     if(!(Object.prototype.toString.call(provider[method]) === "[object Function]")) throw Error("Data provider must provide the methods [" + requiredMethods.join(', ') + "]");
+
+    if(this.legs == 3 &&
+       !(Object.prototype.toString.call(provider.tokenByConsumer) === "[object Function]") &&
+       !(Object.prototype.toString.call(provider.tokenByTokenAndConsumer) === "[object Function]")) {
+        throw new Error("Data provider must provide either tokenByConsumer() or tokenByTokenAndConsumer()");
+    }
   });  
+};
+
+exports.OAuthServices.prototype.tokenByTokenAndConsumer= function(token, consumerKey, callback) {
+  if (Object.prototype.toString.call(this.provider.tokenByTokenAndConsumer) === "[object Function]") {
+    this.provider.tokenByTokenAndConsumer(token, consumerKey, callback);
+  } else if (Object.prototype.toString.call(this.provider.tokenByConsumer) === "[object Function]") {
+    this.provider.tokenByConsumer(consumerKey, callback);
+  } else {
+    callback(new Error("provider: must provide either tokenByConsumer() or tokenByTokenAndConsumer()"), null);
+  }
 };
 
 exports.OAuthServices.prototype.accessToken= function(request, protocol, callback) {
@@ -102,7 +118,7 @@ exports.OAuthServices.prototype.accessToken= function(request, protocol, callbac
     } else {
       if(user.consumer_key == null || user.secret == null) { callback(new errors.OAuthProviderError("provider: applicationByConsumerKey must return a object with fields [token, secret]"), null); return;}
       // Fetch the secret and token for the user
-      self.provider.tokenByConsumer(requestParameters['oauth_consumer_key'], function(err, tokenObject) {
+      self.tokenByTokenAndConsumer(requestParameters["oauth_token"], requestParameters['oauth_consumer_key'], function(err, tokenObject) {
         if(err) {
           callback(new errors.OAuthProviderError('Invalid / expired Token'), null);        
         } else {  


### PR DESCRIPTION
...mer

Per Issue #97, the tokenByConsumer() method assumes only a single
request token per client application.

This would prevent two users from authorizing the same app at the same
time -- unfortunate!

This patch creates a new OAuthDataProvider method,
tokenByTokenAndConsumer(), which retrieves the full value based on
both the token and the consumer_key.

Providers that already implement tokenByConsumer() should continue
working, but newer apps can ignore it and implement the newer method.
