### PR TITLE
Pass correct parameter to previousRequestToken()

### DIFF
--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -132,7 +132,7 @@ exports.OAuthServices.prototype.accessToken= function(request, protocol, callbac
           // Ensure the token is the same as the one passed in from the server
           if(tokenObject.token == requestParameters["oauth_token"]) {
             // Ensure that the key has not been issued before
-            self.provider.previousRequestToken(requestParameters['oauth_consumer_key'], function(err, result) {
+            self.provider.previousRequestToken(requestParameters['oauth_token'], function(err, result) {
               if(err) {
                 callback(new errors.OAuthUnauthorizedError("Invalid / expired Token"), null);
               } else {


### PR DESCRIPTION
We used to pass oauth_consumer_key to previousRequestToken(), which checks for previously used request tokens. This was silently failing to find a previous request token, except where there was a conflict.

This patch makes sure the code passes the correct oauth_token instead.
