### PR TITLE
Add validateNotReplayClient() method for OAuthDataProvider

### DIFF
--- a/examples/in_memory_oauth_data_provider.js
+++ b/examples/in_memory_oauth_data_provider.js
@@ -174,6 +174,10 @@ OAuthDataProvider.prototype.validateNotReplay = function(accessToken, timestamp,
   callback(null, true);
 }
 
+OAuthDataProvider.prototype.validateNotReplayClient = function(consumerKey, accessToken, timestamp, nonce, callback) {
+  callback(null, true);
+}
+
 /**
   Fetch user id based on token (used to identify user in oauth calls later)
 **/

--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -47,7 +47,7 @@ function validateParameters(parameters, requiredParameters) {
 
 exports.OAuthServices= function(provider, legs) {
   this.provider= provider;
-  var requiredMethods = ['applicationByConsumerKey','validateNotReplay'];
+  var requiredMethods = ['applicationByConsumerKey'];
   if (legs) {
     this.legs = legs;
   }
@@ -74,8 +74,14 @@ exports.OAuthServices= function(provider, legs) {
       
     }
   }
-  
 
+  this.providerProvidesValidateNotReplay= (Object.prototype.toString.call(provider.validateNotReplay) === "[object Function]");
+  this.providerProvidesValidateNotReplayClient= (Object.prototype.toString.call(provider.validateNotReplayClient) === "[object Function]");
+  if( !this.providerProvidesTokenByConsumer && !this.providerProvidesTokenByTokenAndConsumer) {
+    throw new Error("Data provider must provide either tokenByConsumer() or tokenByTokenAndConsumer()");
+  }  else {
+    
+  }
 };
 
 exports.OAuthServices.prototype.tokenByTokenAndConsumer= function(token, consumerKey, callback) {
@@ -214,13 +220,23 @@ exports.OAuthServices.prototype.authorize= function(request, protocol, callback)
   
   // Given all the requestParameters and the next step function, error out if the a replay is detected
   var validateNotReplay = function(requestParameters, next) {
-    self.provider.validateNotReplay(requestParameters.oauth_token, requestParameters.oauth_timestamp, requestParameters.oauth_nonce, function(err, result) {
-      if(err) {
-        callback(new errors.OAuthUnauthorizedError('Invalid / used nonce'), null);
-      } else {
-        next();
-      }
-    });
+    if(self.providerProvidesValidateNotReplayClient) {
+      self.provider.validateNotReplayClient(requestParameters.oauth_consumer_key, requestParameters.oauth_token, requestParameters.oauth_timestamp, requestParameters.oauth_nonce, function(err, result) {
+        if(err) {
+          callback(new errors.OAuthUnauthorizedError('Invalid / used nonce'), null);
+        } else {
+          next();
+        }
+      });
+    } else {
+      self.provider.validateNotReplay(requestParameters.oauth_token, requestParameters.oauth_timestamp, requestParameters.oauth_nonce, function(err, result) {
+        if(err) {
+          callback(new errors.OAuthUnauthorizedError('Invalid / used nonce'), null);
+        } else {
+          next();
+        }
+      });
+    }
   };
 
   var getApplicationByConsumerKey = function(consumer_key, next) {

--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -77,8 +77,8 @@ exports.OAuthServices= function(provider, legs) {
 
   this.providerProvidesValidateNotReplay= (Object.prototype.toString.call(provider.validateNotReplay) === "[object Function]");
   this.providerProvidesValidateNotReplayClient= (Object.prototype.toString.call(provider.validateNotReplayClient) === "[object Function]");
-  if( !this.providerProvidesTokenByConsumer && !this.providerProvidesTokenByTokenAndConsumer) {
-    throw new Error("Data provider must provide either tokenByConsumer() or tokenByTokenAndConsumer()");
+  if( !this.providerProvidesValidateNotReplay && !this.providerProvidesValidateNotReplayClient) {
+    throw new Error("Data provider must provide either validateNotReplay() or validateNotReplayClient()");
   }  else {
     
   }


### PR DESCRIPTION
The validateNotReplay() method of the OAuthDataProvider interface takes an accessToken, a timestamp, and a nonce. Per http://tools.ietf.org/html/rfc5849#section-3.3 , "The nonce value MUST be unique across all requests with the same timestamp, client credentials, and token combinations."

However, for 2-legged oauth, an accessToken isn't provided, so the uniqueness can't be verified.

This patch adds another method, validateNotReplayClient() to the OAuthDataProvider interface. It's identical to validateNotReplay(), but it takes another parameter: the consumerKey. This is passed for 2- and 3-legged OAuth.

If the new method is not found, the old one will be used instead.
