### PR TITLE
Change default realm for OAuth to 'oauth'

### DIFF
--- a/lib/auth.strategies/oauth/oauth.js
+++ b/lib/auth.strategies/oauth/oauth.js
@@ -39,7 +39,7 @@ module.exports= function(options) {
   my['authorize_url']=     options['authorize_url']     || '/oauth/authorize';
   my['access_token_url']=  options['access_token_url']  || '/oauth/access_token';
   my['oauth_protocol']=  options['oauth_protocol']  || 'http';
-  my['realm']= options['realm'] || 'realm';
+  my['realm']= options['realm'] || 'oauth';
   my['realm']= my['realm'].replace("\"","\\\"");
 
   my['authenticate_provider']= options['authenticate_provider'];


### PR DESCRIPTION
The documentation comment says the default realm is 'oauth', but the
default code was setting it to the string 'realm'. To harmonize the
two, I used the more descriptive 'oauth'.
