### PR TITLE
ScopedUser Logout Error

### DIFF
--- a/lib/auth_middleware.js
+++ b/lib/auth_middleware.js
@@ -81,7 +81,7 @@ module.exports = function(optionsOrStrategy) {
           middlewareCallback= scope;
           scope= undefined;
         }
-        RequestMethods.logout.call( this, {scope:scope, request:req, response:res}, logoutHandler, function() {
+        RequestMethods.logout.call( this, {scope:scope, request:req, response:res}, logoutHandler, function(err) {
           //Clear out the saved auth details
           //TODO: this should be scope-aware.
           createAuthDetails( req );
@@ -90,7 +90,7 @@ module.exports = function(optionsOrStrategy) {
             traceFunction( message, {scope:scope, request:req, response:res}, linePrefix );
           };
           
-          if( middlewareCallback) middlewareCallback();
+          if( middlewareCallback) middlewareCallback(err);
         })
       };
 

--- a/lib/requestMethods.js
+++ b/lib/requestMethods.js
@@ -1,3 +1,4 @@
+
 /*!
  * Copyright(c) 2010 Ciaran Jessup <ciaranj@gmai.com>
  * MIT Licensed
@@ -156,6 +157,7 @@ module.exports.isUnAuthenticated= function(scope) {
 
 module.exports.logout= function( authContext, logoutHandler, middlewareCallback ) {
   var ad= this.getAuthDetails();
+  var err = null;
   ad.trace( "Logout", authContext.scope, "!!!" );
   var user;
   if( authContext.scope === undefined) {
@@ -168,8 +170,8 @@ module.exports.logout= function( authContext, logoutHandler, middlewareCallback 
       user= ad.scopedUsers[authContext.scope].user;
       delete ad.scopedUsers[authContext.scope].user;
     } catch(error){
-      throw new Error('ScopeError: there are no user credentials associated with the SCOPE requested (' +  authContext.scope + ')');
+      err = new Error('There are no user credentials associated with the scope: "' +  authContext.scope + '"', "sdfsdf");
     }
   }
-  logoutHandler( authContext, user, middlewareCallback );
+  logoutHandler( authContext, user, middlewareCallback(err));
 };

--- a/lib/requestMethods.js
+++ b/lib/requestMethods.js
@@ -170,7 +170,7 @@ module.exports.logout= function( authContext, logoutHandler, middlewareCallback 
       user= ad.scopedUsers[authContext.scope].user;
       delete ad.scopedUsers[authContext.scope].user;
     } catch(error){
-      err = new Error('There are no user credentials associated with the scope: "' +  authContext.scope + '"', "sdfsdf");
+      err = new Error('There are no user credentials associated with the scope: "' +  authContext.scope + '"');
     }
   }
   logoutHandler( authContext, user, middlewareCallback(err));

--- a/lib/requestMethods.js
+++ b/lib/requestMethods.js
@@ -155,17 +155,21 @@ module.exports.isUnAuthenticated= function(scope) {
 };
 
 module.exports.logout= function( authContext, logoutHandler, middlewareCallback ) {
-   var ad= this.getAuthDetails();
-   ad.trace( "Logout", authContext.scope, "!!!" );
-   var user;
-   if( authContext.scope === undefined) {
-     user= ad.user;
-     delete ad.user;
-     ad.scopedUsers= {};
-   }
-   else {
-     user= ad.scopedUsers[authContext.scope].user;
-     delete ad.scopedUsers[authContext.scope].user;
-   }
-   logoutHandler( authContext, user, middlewareCallback );
+  var ad= this.getAuthDetails();
+  ad.trace( "Logout", authContext.scope, "!!!" );
+  var user;
+  if( authContext.scope === undefined) {
+    user= ad.user;
+    delete ad.user;
+    ad.scopedUsers= {};
+  }
+  else {
+    try {
+      user= ad.scopedUsers[authContext.scope].user;
+      delete ad.scopedUsers[authContext.scope].user;
+    } catch(error){
+      throw new Error('ScopeError: there are no user credentials associated with the SCOPE requested (' +  authContext.scope + ')');
+    }
+  }
+  logoutHandler( authContext, user, middlewareCallback );
 };

--- a/lib/requestMethods.js
+++ b/lib/requestMethods.js
@@ -156,10 +156,9 @@ module.exports.isUnAuthenticated= function(scope) {
 };
 
 module.exports.logout= function( authContext, logoutHandler, middlewareCallback ) {
+  var user, err;
   var ad= this.getAuthDetails();
-  var err = null;
   ad.trace( "Logout", authContext.scope, "!!!" );
-  var user;
   if( authContext.scope === undefined) {
     user= ad.user;
     delete ad.user;
@@ -170,7 +169,7 @@ module.exports.logout= function( authContext, logoutHandler, middlewareCallback 
       user= ad.scopedUsers[authContext.scope].user;
       delete ad.scopedUsers[authContext.scope].user;
     } catch(error){
-      err = new Error('There are no user credentials associated with the scope: "' +  authContext.scope + '"');
+      err= new Error('There are no user credentials associated with the scope: "' +  authContext.scope + '"');
     }
   }
   logoutHandler( authContext, user, middlewareCallback(err));


### PR DESCRIPTION
I modified the logout request for scopes to try to delete a user account.  If the user account for that scope does not exist... It will throw a more contextual error instead of simply `user is undefined`

``` javascript
throw new Error('ScopeError: there are no user credentials associated with the SCOPE requested (' +  authContext.scope + ')');
```
