### PR TITLE
authenticateUser() should pass results of associateTokenToUser() to callback

### DIFF
--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -173,7 +173,7 @@ exports.OAuthServices.prototype.authenticateUser = function(username, password, 
     if(result.token == null || result.verifier == null) { callback(new errors.OAuthProviderError("authenticateUser must return a object with fields [token, verifier]"), null); return;}
     // Save the association between the key and the user (to make available for later retrival)
     self.provider.associateTokenToUser(username, result.token, function(err, doc) {
-      callback(err, result);      
+      callback(err, doc);      
     });
   });
 }


### PR DESCRIPTION
The authenticateUser() method of the OAuthServices class was returning
the results of provider.authenticateUser() instead of provider.associateTokenToUser().

This gives incorrect results if associateTokenToUser() doesn't return
the identical object (the in-memory provider does, which is probably why this doesn't come up).

This patch changes the function so that if associateTokenToUser()
returns a non-identical object (say, if you use a database) you get
the most up-to-date object back.
