### PR TITLE
Check the err return from generateAccessToken()

### DIFF
--- a/lib/auth.strategies/oauth/_oauthservices.js
+++ b/lib/auth.strategies/oauth/_oauthservices.js
@@ -153,8 +153,13 @@ exports.OAuthServices.prototype.accessToken= function(request, protocol, callbac
                 // Check if the signature is correct and return a access token
                 if(calculatedSignature == oauth_signature /*|| self.calculateSignatureGoogleWay(method, protocol, url, path, requestParameters, tokenObject.token_secret, user.secret) == requestParameters.oauth_signature */) {
                   self.provider.generateAccessToken(requestParameters['oauth_token'], function(err, result) { 
-                    if(result.access_token == null || result.token_secret == null) { callback(new errors.OAuthProviderError("generateAccessToken must return a object with fields [access_token, token_secret]"), null); return; }
-                    callback(null, result);
+                    if(err) {
+                      callback(new errors.OAuthUnauthorizedError('Invalid / expired Token'), null);
+                    } else if(result.access_token == null || result.token_secret == null) {
+                      callback(new errors.OAuthProviderError("generateAccessToken must return a object with fields [access_token, token_secret]"), null);
+                    } else {
+                      callback(null, result);
+                    }
                   });
                 } else {
                   callback(new errors.OAuthUnauthorizedError("Invalid signature"), null);


### PR DESCRIPTION
We weren't checking the err result from the OAuth provider's
generateAccessToken(), which would cause reference errors if the
result was null or undefined.

Now, check it, and return an error if there is one.
