### PR TITLE
Updates for GitHub API v3 authentication

### DIFF
--- a/lib/auth.strategies/github.js
+++ b/lib/auth.strategies/github.js
@@ -55,12 +55,12 @@ module.exports= function(options, server) {
                                          else {
                                            request.session["access_token"]= access_token;
                                            if( refresh_token ) request.session["refresh_token"]= refresh_token;
-                                             my._oAuth.getProtectedResource("https://github.com/api/v2/json/user/show", request.session["access_token"], function (error, data, response) {
+                                             my._oAuth.getProtectedResource("https://api.github.com/user", request.session["access_token"], function (error, data, response) {
                                              if( error ) {
                                                request.getAuthDetails()['github_login_attempt_failed'] = true;
                                                self.fail(callback);
                                              }else {
-                                               self.success(JSON.parse(data).user, callback)
+                                               self.success(JSON.parse(data), callback)
                                              }
                                            })
                                          }


### PR DESCRIPTION
These changes are necessary because GitHub shut off all API versions prior to v3.
