### PR TITLE
Ability to specify fields to request on Facebook Auth strategy

### DIFF
--- a/lib/auth.strategies/facebook.js
+++ b/lib/auth.strategies/facebook.js
@@ -16,6 +16,7 @@ module.exports= function(options, server) {
   my._redirectUri= options.callback;
   my.scope= options.scope || "";
   my.display =options.display || "page";
+  my.fields=options.fields || "";
 
   // Give the strategy a name
   that.name  = options.name || "facebook";
@@ -34,6 +35,8 @@ module.exports= function(options, server) {
   that.authenticate= function(request, response, callback) {
     //todo: makw the call timeout ....
     var parsedUrl= url.parse(request.originalUrl, true);
+    var fb_url = "https://graph.facebook.com/me" + (my.fields ? "?fields=" + my.fields : "");
+
     var self= this; 
     this._facebook_fail= function(callback) {
          request.getAuthDetails()['facebook_login_attempt_failed'] = true;
@@ -58,7 +61,8 @@ module.exports= function(options, server) {
                                          else {
                                            request.session["access_token"]= access_token;
                                            if( refresh_token ) request.session["refresh_token"]= refresh_token;
-                                             my._oAuth.getProtectedResource("https://graph.facebook.com/me", request.session["access_token"], function (error, data, response) {
+
+                                             my._oAuth.getProtectedResource(fb_url, request.session["access_token"], function (error, data, response) {
                                              if( error ) {
                                                self._facebook_fail(callback);
                                              }else {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main" : "lib/index.js",
   "directories" : { "lib" : "./lib" },
   "dependencies" : {
-      "connect": "2.0.0"
+      "connect": ">=2.0.0"
      , "oauth":  "0.9.7"
      , "openid": "0.4.1"
   },


### PR DESCRIPTION
Currently when Facebook Auth makes a call to Facebook to authenticate and get an access token, the default fields are pulled from "https://graph.facebook.com/me". This does not allow a developer to take full advantage of the scope they may have specified when implementing the Auth Strategy because some fields may be omitted, requiring another implementation to get those fields.

This change allows an additional option to be specified when the Auth Strategy is implemented called "fields". This option is specified at the same time fb_scope, fb_appid, and fb_secret are defined. This will then grab the exact fields Facebook at authentication. If no fields are specified, the defaults will be used.

Here's an example:

```
// Declare Auth Strategy fields
var example_fields = "id,name,first_name,middle_name,last_name,gender,locale,picture,timezone,email,birthday,location,games,hometown,religion,political,relationship_status,likes"

//... implement on Connect/Express
auth.Facebook({name:'auth_name', appId:config.auth.facebook.app_id, appSecret:config.auth.facebook.secret, scope:config.auth.facebook.scope, fields:example_fields)

//... In use. Pulling the likes field
var likes = req.getAuthDetails().user.likes
```

This change also increases support for all versions of Connect above 2.0.
