### PR TITLE
Use Connect 2.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main" : "lib/index.js",
   "directories" : { "lib" : "./lib" },
   "dependencies" : {
-      "connect": "2.0.0"
+      "connect": "2.7.x"
      , "oauth":  "0.9.7"
      , "openid": "0.4.1"
   },


### PR DESCRIPTION
Update package.json to depend on connect 2.7.x.

Closes #121.
