### PR TITLE
add option to force user re-approval of app in the google2 strategy

### DIFF
--- a/lib/auth.strategies/google2.js
+++ b/lib/auth.strategies/google2.js
@@ -16,6 +16,7 @@ module.exports= function(options, server) {
   my._redirectUri= options.callback;
   my.scope= options.scope || "https://www.googleapis.com/auth/userinfo.profile";
   my.accessType = options.accessType || null;
+  my.forceApproval = options.forceApproval || false;
 
   // Ensure we have the correct scopes to match what the consumer really wants.
   if( options.requestEmailPermission === true && my.scope.indexOf("auth/userinfo.email") == -1 ) {
@@ -104,6 +105,9 @@ module.exports= function(options, server) {
          // support offline access as per https://developers.google.com/accounts/docs/OAuth2WebServer#offline
          if(my.accessType !== null)
              urlParams.access_type = my.accessType; // access_type=offline
+         // force displaying the approval prompt to the user. In such a case, a refresh_token will be regenerated.
+         if (my.forceApproval)
+            urlParams.approval_prompt = 'force';
          var redirectUrl= my._oAuth.getAuthorizeUrl(urlParams);
          self.redirect(response, redirectUrl, callback);
        }


### PR DESCRIPTION
as per https://developers.google.com/accounts/docs/OAuth2WebServer#offline the only way to regenerate a refresh_token (for offline use), is to force the user to re-approve the app. This commit adds the optional "forceApproval" option. If present and is true, it will trigger the display of the approval prompt to the user.
